### PR TITLE
Email confirmation after sign up

### DIFF
--- a/app/controllers/web/confirmations_controller.rb
+++ b/app/controllers/web/confirmations_controller.rb
@@ -1,0 +1,11 @@
+class Web::ConfirmationsController < Web::BaseController
+  # GET /confirmations
+  def create
+    token = params[:token]
+    if User.find_by(confirmation_token: token)&.confirm!
+      redirect_to root_url, notice: "Your email is confirmed successfully!"
+    else
+      redirect_to root_url, alert: "What the hell are you doing?!"
+    end
+  end
+end

--- a/app/controllers/web/users_controller.rb
+++ b/app/controllers/web/users_controller.rb
@@ -8,6 +8,7 @@ class Web::UsersController < Web::BaseController
   def create
     @user = User.create(user_params)
     if @user.valid?
+      UserMailer.with(user: @user).confirm.deliver_later
       redirect_to root_url, notice: "Your account is successfully created!"
     else
       render :new

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,8 @@
+class UserMailer < ApplicationMailer
+  default from: "rails-pg@example.com"
+
+  def confirm
+    @user = params[:user]
+    mail to: @user.email, subject: "Confirm your email address"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,16 @@ class User < ApplicationRecord
   # `length` limitation is for view styling
   validates :username, presence: true, uniqueness: true, length: { maximum: 16 }
   validates :email,    presence: true, uniqueness: true, format: { with: EMAIL_REGEXP }
+
+  before_create :assign_confirmation_token
+
+  def confirm!
+    update!(confirmed_at: Time.current)
+  end
+
+  private
+
+  def assign_confirmation_token
+    self.confirmation_token ||= SecureRandom.urlsafe_base64
+  end
 end

--- a/app/views/user_mailer/confirm.text.erb
+++ b/app/views/user_mailer/confirm.text.erb
@@ -1,0 +1,7 @@
+Welcome to RailsPg! Please confirm your email address
+=====================================================
+
+Click the below link to confirm:
+
+<%= confirmations_url(token: @user.confirmation_token) %>
+

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,4 +58,9 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.action_mailer.default_url_options = {
+    host: "www.lvh.me",
+    port: 3000,
+  }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,4 +43,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.action_mailer.default_url_options = {
+    host: "www.lvh.me",
+  }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
       get    "login",  to: "sessions#new",     as: :login
       delete "logout", to: "sessions#destroy", as: :logout
 
+      get "confirmations", to: "confirmations#create", as: :confirmations
+
       resources :users, only: %i(new create)
       resources :sessions, only: %i(create)
     end

--- a/db/migrate/20181009090811_add_confirmation_columns_to_users.rb
+++ b/db/migrate/20181009090811_add_confirmation_columns_to_users.rb
@@ -1,0 +1,6 @@
+class AddConfirmationColumnsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :confirmation_token, :string, after: :password_digest
+    add_column :users, :confirmed_at, :datetime, after: :confirmation_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_27_085516) do
+ActiveRecord::Schema.define(version: 2018_10_09_090811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define(version: 2018_09_27_085516) do
     t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
   end
 
 end

--- a/test/controllers/web/confirmations_controller_test.rb
+++ b/test/controllers/web/confirmations_controller_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class Web::ConfirmationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:mmyoji)
+    @user.update!(confirmation_token: SecureRandom.urlsafe_base64)
+  end
+
+  test "GET #confirmations redirects to root_url" do
+    get confirmations_url(token: @user.confirmation_token)
+
+    assert_redirected_to root_url
+  end
+end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,7 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+class UserMailerPreview < ActionMailer::Preview
+  def confirm
+    user = User.find_by!(username: "mmyoji")
+    UserMailer.with(user: user).confirm
+  end
+end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class UserMailerTest < ActionMailer::TestCase
+  setup do
+    @user = users(:mmyoji)
+  end
+
+  test "#confirm sends confirmation mail" do
+    email = UserMailer.with(user: @user).confirm
+    assert_emails 1 do
+      email.deliver_now
+    end
+    assert_equal ["rails-pg@example.com"], email.from
+    assert_equal [@user.email], email.to
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -63,4 +63,19 @@ class UserTest < ActiveSupport::TestCase
     user = User.new(@params.merge(password: real_pswd, password_confirmation: real_pswd))
     assert user.valid?
   end
+
+  test "confirmation_token must be set" do
+    user = User.new(@params)
+    refute user.confirmation_token?
+
+    user.save!
+    assert user.confirmation_token?
+  end
+
+  test "#confirm! updates confirmed_at" do
+    refute @user.confirmed_at?
+
+    @user.confirm!
+    assert @user.confirmed_at?
+  end
 end


### PR DESCRIPTION
Send a confirmation email after sign up, and the user follows the instruction, then confirmed :tada: 

There's nothing to be regulated currently if users don't confirm the emails. But something will be so in future, i guess.
